### PR TITLE
Add go.mod file for module definition and Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devzeeh/barcodemail
+
+go 1.25.0


### PR DESCRIPTION
Introduce a go.mod file to define the module and specify the Go version as 1.25.0.