### PR TITLE
Fix variable naming in MailData struct and update references in email handling

### DIFF
--- a/barcode.go
+++ b/barcode.go
@@ -21,8 +21,7 @@ import (
 // This is useful for generating unique identifiers for barcodes and QR codes.
 var (
 	vrand         = rand.New(rand.NewSource(time.Now().UnixNano()))
-	randomBarcode = vrand.Intn(9000) + 1000 // Always generate a 4-digit random number (1000-9999)
-	randomQR      = vrand.Intn(9000) + 1000
+	randomQR      = vrand.Intn(9000) + 1000// Always generate a 4-digit random number (1000-9999)
 )
 
 // Filepath creates the file and returns the file pointer

--- a/email/email.go
+++ b/email/email.go
@@ -38,7 +38,7 @@ func SenderName(name string) {
 // MailData holds the data required to send an email.
 // It includes the recipient's email, subject, body, QR code file path, and content ID for embedding images.
 type MailData struct {
-	ToEmail string // Recipient's email address
+	From    string // Recipient's email address
 	Subject string // Subject of the email
 	Body    string // HTML body of the email
 	Qrcode  string // File path of the QR code image
@@ -50,14 +50,14 @@ type MailData struct {
 func Mail(Mail MailData) {
 	// sanity check
 
-	// SMTP Config
+	// SMTP Config of Gmail
 	smtpHost := "smtp.gmail.com"
 	smtpPort := 587
 
-	// Create email
+	// Create
 	m := gomail.NewMessage()
 	m.SetHeader("From", fmt.Sprintf("%s <%s>", senderName, senderEmail))
-	m.SetHeader("To", Mail.ToEmail)
+	m.SetHeader("To", Mail.From)
 	m.SetHeader("Subject", Mail.Subject)
 	m.SetBody("text/html", Mail.Body)
 

--- a/email/email.go
+++ b/email/email.go
@@ -54,7 +54,7 @@ func Mail(Mail MailData) {
 	smtpHost := "smtp.gmail.com"
 	smtpPort := 587
 
-	// Create
+	// Create email
 	m := gomail.NewMessage()
 	m.SetHeader("From", fmt.Sprintf("%s <%s>", senderName, senderEmail))
 	m.SetHeader("To", Mail.From)

--- a/test/test.go
+++ b/test/test.go
@@ -30,7 +30,7 @@ func main() {
 	`, data, contentID)
 
 	sendData := email.MailData{
-		ToEmail: "user@test.com",
+		From: "user@test.com",
 		Subject: "Barcodemail",
 		Body:    body,
 		Qrcode:  file,


### PR DESCRIPTION
Update the `MailData` struct to use `From` instead of `ToEmail` for clarity and adjust all related references accordingly.